### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+/target
+test/target
+test/Cargo.lock
+**/*.rs.bk
+/devtools/ci/travis-secret.asc
+
+# nix
+result
+result-*


### PR DESCRIPTION
This will make nix-shell much faster as it won't try to hash all of `/target`.