### PR TITLE
Fix witnesses

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -8,7 +8,10 @@ use ckb_cli_plugin_protocol::{
 use ckb_jsonrpc_types::JsonBytes;
 use ckb_sdk::wallet::{DerivationPath, DerivedKeySet};
 
-use crate::keystore::{to_annotated_transaction, CanDeriveSecp256k1PublicKey, LedgerId, LedgerKeyStore, LedgerKeyStoreError};
+use crate::keystore::{
+    to_annotated_transaction, CanDeriveSecp256k1PublicKey, LedgerId, LedgerKeyStore,
+    LedgerKeyStoreError,
+};
 
 pub fn handle(keystore: &mut LedgerKeyStore, request: PluginRequest) -> Option<PluginResponse> {
     match request {
@@ -216,7 +219,9 @@ fn keystore_handler(
                     inputs,
                     change_path,
                 } => {
-                    let signing_lock_arg = crate::keystore::hash_public_key(&ledger_cap.secp256k1_extended_public_key().public_key);
+                    let signing_lock_arg = crate::keystore::hash_public_key(
+                        &ledger_cap.secp256k1_extended_public_key().public_key,
+                    );
                     let signature = ledger_cap.begin_sign_recoverable(to_annotated_transaction(
                         tx,
                         inputs,

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -8,7 +8,7 @@ use ckb_cli_plugin_protocol::{
 use ckb_jsonrpc_types::JsonBytes;
 use ckb_sdk::wallet::{DerivationPath, DerivedKeySet};
 
-use crate::keystore::{to_annotated_transaction, LedgerId, LedgerKeyStore, LedgerKeyStoreError, LedgerMasterCap};
+use crate::keystore::{to_annotated_transaction, CanDeriveSecp256k1PublicKey, LedgerId, LedgerKeyStore, LedgerKeyStoreError};
 
 pub fn handle(keystore: &mut LedgerKeyStore, request: PluginRequest) -> Option<PluginResponse> {
     match request {
@@ -216,8 +216,7 @@ fn keystore_handler(
                     inputs,
                     change_path,
                 } => {
-                    let path_drv = DerivationPath::from_str(path.as_str())?;
-                    let signing_lock_arg = LedgerMasterCap::public_key_to_lock_arg(account.derive_public_key(&path_drv)?);
+                    let signing_lock_arg = crate::keystore::public_key_to_lock_arg(ledger_cap.secp256k1_extended_public_key().public_key);
                     let signature = ledger_cap.begin_sign_recoverable(to_annotated_transaction(
                         tx,
                         inputs,

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -8,10 +8,7 @@ use ckb_cli_plugin_protocol::{
 use ckb_jsonrpc_types::JsonBytes;
 use ckb_sdk::wallet::{DerivationPath, DerivedKeySet};
 
-use crate::keystore::{
-    to_annotated_transaction, CanDeriveSecp256k1PublicKey, LedgerId, LedgerKeyStore,
-    LedgerKeyStoreError,
-};
+use crate::keystore::{to_annotated_transaction, LedgerId, LedgerKeyStore, LedgerKeyStoreError};
 
 pub fn handle(keystore: &mut LedgerKeyStore, request: PluginRequest) -> Option<PluginResponse> {
     match request {
@@ -219,13 +216,10 @@ fn keystore_handler(
                     inputs,
                     change_path,
                 } => {
-                    let signing_lock_arg = crate::keystore::hash_public_key(
-                        &ledger_cap.secp256k1_extended_public_key().public_key,
-                    );
                     let signature = ledger_cap.begin_sign_recoverable(to_annotated_transaction(
                         tx,
                         inputs,
-                        signing_lock_arg,
+                        ledger_cap.lock_arg(),
                         change_path,
                     ))?;
                     Ok(PluginResponse::Bytes(JsonBytes::from_vec(signature)))

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -123,7 +123,7 @@ fn keystore_handler(
         } => {
             let master = keystore.borrow_account(&hash160)?;
             let drv_path = DerivationPath::from_str(&path).unwrap();
-            let public_key = master.as_ledger_cap()
+            let public_key = master
                 .child_from_root_path(drv_path.as_ref())?
                 .public_key_prompt()?;
             Ok(PluginResponse::Bytes(JsonBytes::from_vec(
@@ -196,7 +196,7 @@ fn keystore_handler(
             // );
             let master = keystore.borrow_account(&hash160)?;
             let drv_path = DerivationPath::from_str(&path).unwrap();
-            let ledger_cap = master.as_ledger_cap().child_from_root_path(drv_path.as_ref())?;
+            let ledger_cap = master.child_from_root_path(drv_path.as_ref())?;
             let sign_msg = |(msg, display_hex)| -> Result<_, LedgerKeyStoreError> {
                 let magic_string = String::from("Nervos Message:");
                 let magic_bytes = magic_string.as_bytes();

--- a/src/keystore.rs
+++ b/src/keystore.rs
@@ -416,8 +416,8 @@ impl LedgerAccount {
         path: &[ChildNumber],
     ) -> Result<LedgerAccount, LedgerKeyStoreError> {
         if self.root_path_is_child(path) {
-            path.iter()
-                .skip(self.path.as_ref().len())
+            path[self.path.as_ref().len()..]
+                .iter()
                 .fold(Ok(self.clone()), |account, &child| account?.child(child))
         } else {
             Err(LedgerKeyStoreError::InvalidDerivationPath {
@@ -805,7 +805,7 @@ pub fn to_annotated_transaction(
                     None
                 }
             })
-            .chain(tx.witnesses.iter().skip(num_inputs).cloned())
+            .chain(tx.witnesses[num_inputs..].iter().cloned())
             .map(From::from)
             .collect::<Vec<_>>()
     };


### PR DESCRIPTION
The ledger does not group witnesses so we need to only give it witnesses that either correspond to the current signing key or extra witnesses that don't map to a specific transaction input.